### PR TITLE
fix torch.clamp for homogeneous division

### DIFF
--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -79,10 +79,10 @@ def convert_points_from_homogeneous(points: torch.Tensor) -> torch.Tensor:
     if len(points.shape) < 2:
         raise ValueError("Input must be at least a 2D tensor. Got {}".format(
             points.shape))
+
     # we check for points at infinity
     z_vec: torch.Tensor = points[..., -1:]
-    z_vec[(z_vec >= 0.) * (z_vec < EPS)] = EPS
-    z_vec[(z_vec < 0.) * (z_vec > -EPS)] = -EPS
+    z_vec = torch.where(torch.abs(z_vec) > EPS, z_vec, torch.sign(z_vec) * EPS)
     scale: torch.Tensor = torch.tensor(1.) / z_vec
 
     return scale * points[..., :-1]

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -81,8 +81,8 @@ def convert_points_from_homogeneous(points: torch.Tensor) -> torch.Tensor:
             points.shape))
     # we check for points at infinity
     z_vec: torch.Tensor = points[..., -1:]
-    z_vec[(z_vec >= 0) * (z_vec < 1e-6)] = EPS
-    z_vec[(z_vec < 0) * (z_vec > -1e-6)] = -EPS
+    z_vec[(z_vec >= 0) * (z_vec < EPS)] = EPS
+    z_vec[(z_vec < 0) * (z_vec > -EPS)] = -EPS
     scale: torch.Tensor = torch.tensor(1.) / z_vec
 
     return scale * points[..., :-1]

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -83,9 +83,12 @@ def convert_points_from_homogeneous(points: torch.Tensor) -> torch.Tensor:
     # we check for points at infinity
     z_vec: torch.Tensor = points[..., -1:]
     # set the results of division by zeror/near-zero to 1.0
-    # follow the convention of opencv: https://github.com/opencv/opencv/pull/14411/files
-    scale: torch.Tensor = torch.where(torch.abs(z_vec) > EPS,
-        torch.tensor(1.) / z_vec, torch.ones_like(z_vec))
+    # follow the convention of opencv:
+    # https://github.com/opencv/opencv/pull/14411/files
+    scale: torch.Tensor = torch.where(
+        torch.abs(z_vec) > EPS,
+        torch.tensor(1.) / z_vec,
+        torch.ones_like(z_vec))
 
     return scale * points[..., :-1]
 

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -81,8 +81,8 @@ def convert_points_from_homogeneous(points: torch.Tensor) -> torch.Tensor:
             points.shape))
     # we check for points at infinity
     z_vec: torch.Tensor = points[..., -1:]
-    z_vec[(z_vec >= 0) * (z_vec < EPS)] = EPS
-    z_vec[(z_vec < 0) * (z_vec > -EPS)] = -EPS
+    z_vec[(z_vec >= 0.) * (z_vec < EPS)] = EPS
+    z_vec[(z_vec < 0.) * (z_vec > -EPS)] = -EPS
     scale: torch.Tensor = torch.tensor(1.) / z_vec
 
     return scale * points[..., :-1]

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -82,8 +82,10 @@ def convert_points_from_homogeneous(points: torch.Tensor) -> torch.Tensor:
 
     # we check for points at infinity
     z_vec: torch.Tensor = points[..., -1:]
-    z_vec = torch.where(torch.abs(z_vec) > EPS, z_vec, torch.sign(z_vec) * EPS)
-    scale: torch.Tensor = torch.tensor(1.) / z_vec
+    # set the results of division by zeror/near-zero to 1.0
+    # follow the convention of opencv: https://github.com/opencv/opencv/pull/14411/files
+    scale: torch.Tensor = torch.where(torch.abs(z_vec) > EPS,
+        torch.tensor(1.) / z_vec, torch.ones_like(z_vec))
 
     return scale * points[..., :-1]
 

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -79,10 +79,11 @@ def convert_points_from_homogeneous(points: torch.Tensor) -> torch.Tensor:
     if len(points.shape) < 2:
         raise ValueError("Input must be at least a 2D tensor. Got {}".format(
             points.shape))
-
     # we check for points at infinity
     z_vec: torch.Tensor = points[..., -1:]
-    scale: torch.Tensor = torch.tensor(1.) / torch.clamp(z_vec, EPS)
+    z_vec[(z_vec >= 0) * (z_vec < 1e-6)] = EPS
+    z_vec[(z_vec < 0) * (z_vec > -1e-6)] = -EPS
+    scale: torch.Tensor = torch.tensor(1.) / z_vec
 
     return scale * points[..., :-1]
 

--- a/test/geometry/test_conversions.py
+++ b/test/geometry/test_conversions.py
@@ -176,7 +176,7 @@ class TestConvertPointsFromHomogeneous:
         expected = torch.FloatTensor([
             [1, 2],
             [0, 0.5],
-            [2e6, 1e6],
+            [2, 1],
         ]).to(torch.device(device_type))
 
         # to euclidean
@@ -192,7 +192,7 @@ class TestConvertPointsFromHomogeneous:
         ]]).to(torch.device(device_type))
 
         expected = torch.FloatTensor([[
-            [2e6, 1e6],
+            [2, 1],
         ], [
             [0, 0.5],
         ]]).to(torch.device(device_type))

--- a/test/geometry/test_conversions.py
+++ b/test/geometry/test_conversions.py
@@ -171,12 +171,16 @@ class TestConvertPointsFromHomogeneous:
             [1, 2, 1],
             [0, 1, 2],
             [2, 1, 0],
+            [-1, -2, -1],
+            [0, 1, -2],
         ]).to(torch.device(device_type))
 
         expected = torch.FloatTensor([
             [1, 2],
             [0, 0.5],
             [2, 1],
+            [1, 2],
+            [0, -0.5],
         ]).to(torch.device(device_type))
 
         # to euclidean
@@ -189,12 +193,16 @@ class TestConvertPointsFromHomogeneous:
             [2, 1, 0],
         ], [
             [0, 1, 2],
+        ], [
+            [0, 1, -2],
         ]]).to(torch.device(device_type))
 
         expected = torch.FloatTensor([[
             [2, 1],
         ], [
             [0, 0.5],
+        ], [
+            [0, -0.5],
         ]]).to(torch.device(device_type))
 
         # to euclidean


### PR DESCRIPTION
clamp operation clamps all elements in input to be larger or equal min(EPS).
But it doesn't work for negative elements.
In this implementation, it checks for both small positive and small negative elements, and set them to EPS value.