### PR TITLE
batch support for tensor2img and img2tensor

### DIFF
--- a/kornia/utils/image.py
+++ b/kornia/utils/image.py
@@ -4,29 +4,80 @@ import numpy as np
 import torch
 
 
+def hw_image_to_hw_tensor(image: np.array) -> torch.Tensor:
+    if len(image.shape) != 2:
+        raise ValueError("Input size must be a two dimensional array")
+    tensor: torch.Tensor = torch.from_numpy(image)
+    return tensor
+
+
+def hwc_image_to_chw_tensor(image: np.array) -> torch.Tensor:
+    if len(image.shape) != 3:
+        raise ValueError("Input size must be a three dimensional array")
+    tensor: torch.Tensor = torch.from_numpy(image)
+    tensor = tensor.permute(2, 0, 1)
+    return tensor
+
+
+def bhwc_image_to_bchw_tensor(image: np.array) -> torch.Tensor:
+    if len(image.shape) != 4:
+        raise ValueError("Input size must be a four dimensional array")
+    tensor: torch.Tensor = torch.from_numpy(image)
+    tensor = tensor.permute(0, 3, 1, 2)
+    return tensor
+
+
 def image_to_tensor(image: np.array) -> torch.Tensor:
     """Converts a numpy image to a PyTorch tensor image.
 
     Args:
-        image (numpy.ndarray): image of the form :math:`(H, W, C)`.
+        image (numpy.ndarray): image of the form :math:`(H, W)`, math:`(H, W, C)`, 
+        or math:`(B, H, W, C)`.
 
     Returns:
-        torch.Tensor: tensor of the form :math:`(C, H, W)`.
+        torch.Tensor: tensor of the form :math:`(H, W)`, math:`(C, H, W)`, 
+        or math:`(B, C, H, W)`.
 
     """
-    if not type(image) == np.ndarray:
+    if not isinstance(image, np.ndarray):
         raise TypeError("Input type is not a numpy.ndarray. Got {}".format(
             type(image)))
 
-    if len(image.shape) > 3 or len(image.shape) < 2:
-        raise ValueError("Input size must be a two or three dimensional array")
+    if len(image.shape) > 4 or len(image.shape) < 2:
+        raise ValueError(
+            "Input size must be a two, three or four dimensional array")
 
-    tensor: torch.Tensor = torch.from_numpy(image)
+    input_shape = image.shape
+    if len(input_shape) == 2:
+        tensor: torch.Tensor = hw_image_to_hw_tensor(image)
+    elif len(input_shape) == 3:
+        tensor: torch.Tensor = hwc_image_to_chw_tensor(image)
+    elif len(input_shape) == 4:
+        tensor: torch.Tensor = bhwc_image_to_bchw_tensor(image)
+    else:
+        raise ValueError("Cannot process image with shape {}".format(input_shape))
+    return tensor
 
-    if len(tensor.shape) == 2:
-        tensor = torch.unsqueeze(tensor, dim=-1)
 
-    return tensor.permute(2, 0, 1).squeeze_()  # CxHxW
+def hw_tensor_to_hw_image(tensor: torch.Tensor) -> np.array:
+    if len(tensor.shape) != 2:
+        raise ValueError("Input size must be a two dimensional array")
+    image: np.array = tensor.cpu().detach().numpy()
+    return image
+
+
+def chw_tensor_to_hwc_image(tensor: torch.Tensor) -> np.array:
+    if len(tensor.shape) != 3:
+        raise ValueError("Input size must be a three dimensional array")
+    image: np.array = tensor.permute(1, 2, 0).cpu().detach().numpy()
+    return image
+
+
+def bchw_tensor_to_bhwc_image(tensor: torch.Tensor) -> np.array:
+    if len(tensor.shape) != 4:
+        raise ValueError("Input size must be a four dimensional array")
+    image: np.array = tensor.permute(0, 2, 3, 1).cpu().detach().numpy()
+    return image
 
 
 def tensor_to_image(tensor: torch.Tensor) -> np.array:
@@ -34,27 +85,30 @@ def tensor_to_image(tensor: torch.Tensor) -> np.array:
     in the GPU, it will be copied back to CPU.
 
     Args:
-        tensor (torch.Tensor): image of the form :math:`(C, H, W)`.
+        tensor (torch.Tensor): image of the form :math:`(H, W)`, math:`(C, H, W)`, 
+        or math:`(B, C, H, W)`.
 
     Returns:
-        numpy.ndarray: image of the form :math:`(H, W, C)`.
+        numpy.ndarray: image of the form :math:`(H, W)`, math:`(H, W, C)`, 
+        or math:`(B, H, W, C)`.
 
     """
     if not torch.is_tensor(tensor):
         raise TypeError("Input type is not a torch.Tensor. Got {}".format(
             type(tensor)))
 
-    if len(tensor.shape) > 3 or len(tensor.shape) < 2:
+    if len(tensor.shape) > 4 or len(tensor.shape) < 2:
         raise ValueError(
-            "Input size must be a two or three dimensional tensor")
+            "Input size must be a two, three or four dimensional tensor")
 
     input_shape = tensor.shape
     if len(input_shape) == 2:
-        tensor = torch.unsqueeze(tensor, dim=0)
+        image: np.array = hw_tensor_to_hw_image(tensor)
+    elif len(input_shape) == 3:
+        image: np.array = chw_tensor_to_hwc_image(tensor)
+    elif len(input_shape) == 4:
+        image: np.array = bchw_tensor_to_bhwc_image(tensor)
+    else:
+        raise ValueError("Cannot process tensor with shape {}".format(input_shape))
 
-    tensor = tensor.permute(1, 2, 0)
-
-    if len(input_shape) == 2:
-        tensor = torch.squeeze(tensor, dim=-1)
-
-    return tensor.cpu().detach().numpy()
+    return image

--- a/kornia/utils/image.py
+++ b/kornia/utils/image.py
@@ -4,39 +4,16 @@ import numpy as np
 import torch
 
 
-def hw_image_to_hw_tensor(image: np.array) -> torch.Tensor:
-    if len(image.shape) != 2:
-        raise ValueError("Input size must be a two dimensional array")
-    tensor: torch.Tensor = torch.from_numpy(image)
-    return tensor
-
-
-def hwc_image_to_chw_tensor(image: np.array) -> torch.Tensor:
-    if len(image.shape) != 3:
-        raise ValueError("Input size must be a three dimensional array")
-    tensor: torch.Tensor = torch.from_numpy(image)
-    tensor = tensor.permute(2, 0, 1)
-    return tensor
-
-
-def bhwc_image_to_bchw_tensor(image: np.array) -> torch.Tensor:
-    if len(image.shape) != 4:
-        raise ValueError("Input size must be a four dimensional array")
-    tensor: torch.Tensor = torch.from_numpy(image)
-    tensor = tensor.permute(0, 3, 1, 2)
-    return tensor
-
-
 def image_to_tensor(image: np.array) -> torch.Tensor:
     """Converts a numpy image to a PyTorch tensor image.
 
     Args:
-        image (numpy.ndarray): image of the form :math:`(H, W)`, math:`(H, W, C)`, 
-        or math:`(B, H, W, C)`.
+        image (numpy.ndarray): image of the form :math:`(H, W)`,
+        math:`(H, W, C)`, or math:`(B, H, W, C)`.
 
     Returns:
-        torch.Tensor: tensor of the form :math:`(H, W)`, math:`(C, H, W)`, 
-        or math:`(B, C, H, W)`.
+        torch.Tensor: tensor of the form :math:`(H, W)`,
+        math:`(C, H, W)`, or math:`(B, C, H, W)`.
 
     """
     if not isinstance(image, np.ndarray):
@@ -48,36 +25,20 @@ def image_to_tensor(image: np.array) -> torch.Tensor:
             "Input size must be a two, three or four dimensional array")
 
     input_shape = image.shape
+    tensor: torch.Tensor = torch.from_numpy(image)
     if len(input_shape) == 2:
-        tensor: torch.Tensor = hw_image_to_hw_tensor(image)
+        # (H, W) -> (H, W)
+        tensor = tensor
     elif len(input_shape) == 3:
-        tensor: torch.Tensor = hwc_image_to_chw_tensor(image)
+        # (H, W, C) -> (C, H, W)
+        tensor = tensor.permute(2, 0, 1)
     elif len(input_shape) == 4:
-        tensor: torch.Tensor = bhwc_image_to_bchw_tensor(image)
+        # (B, H, W, C) -> (B, C, H, W)
+        tensor = tensor.permute(0, 3, 1, 2)
     else:
-        raise ValueError("Cannot process image with shape {}".format(input_shape))
+        raise ValueError(
+            "Cannot process image with shape {}".format(input_shape))
     return tensor
-
-
-def hw_tensor_to_hw_image(tensor: torch.Tensor) -> np.array:
-    if len(tensor.shape) != 2:
-        raise ValueError("Input size must be a two dimensional array")
-    image: np.array = tensor.cpu().detach().numpy()
-    return image
-
-
-def chw_tensor_to_hwc_image(tensor: torch.Tensor) -> np.array:
-    if len(tensor.shape) != 3:
-        raise ValueError("Input size must be a three dimensional array")
-    image: np.array = tensor.permute(1, 2, 0).cpu().detach().numpy()
-    return image
-
-
-def bchw_tensor_to_bhwc_image(tensor: torch.Tensor) -> np.array:
-    if len(tensor.shape) != 4:
-        raise ValueError("Input size must be a four dimensional array")
-    image: np.array = tensor.permute(0, 2, 3, 1).cpu().detach().numpy()
-    return image
 
 
 def tensor_to_image(tensor: torch.Tensor) -> np.array:
@@ -85,12 +46,12 @@ def tensor_to_image(tensor: torch.Tensor) -> np.array:
     in the GPU, it will be copied back to CPU.
 
     Args:
-        tensor (torch.Tensor): image of the form :math:`(H, W)`, math:`(C, H, W)`, 
-        or math:`(B, C, H, W)`.
+        tensor (torch.Tensor): image of the form :math:`(H, W)`,
+        math:`(C, H, W)`, or math:`(B, C, H, W)`.
 
     Returns:
-        numpy.ndarray: image of the form :math:`(H, W)`, math:`(H, W, C)`, 
-        or math:`(B, H, W, C)`.
+        numpy.ndarray: image of the form :math:`(H, W)`,
+        math:`(H, W, C)`, or math:`(B, H, W, C)`.
 
     """
     if not torch.is_tensor(tensor):
@@ -102,13 +63,18 @@ def tensor_to_image(tensor: torch.Tensor) -> np.array:
             "Input size must be a two, three or four dimensional tensor")
 
     input_shape = tensor.shape
+    image: np.array = tensor.cpu().detach().numpy()
     if len(input_shape) == 2:
-        image: np.array = hw_tensor_to_hw_image(tensor)
+        # (H, W) -> (H, W)
+        image = image
     elif len(input_shape) == 3:
-        image: np.array = chw_tensor_to_hwc_image(tensor)
+        # (C, H, W) -> (H, W, C)
+        image = image.transpose(1, 2, 0)
     elif len(input_shape) == 4:
-        image: np.array = bchw_tensor_to_bhwc_image(tensor)
+        # (B, C, H, W) -> (B, H, W, C)
+        image = image.transpose(0, 2, 3, 1)
     else:
-        raise ValueError("Cannot process tensor with shape {}".format(input_shape))
+        raise ValueError(
+            "Cannot process tensor with shape {}".format(input_shape))
 
     return image

--- a/test/utils/test_image.py
+++ b/test/utils/test_image.py
@@ -7,19 +7,27 @@ import kornia as kornia
 import utils  # test utils
 
 
-@pytest.mark.parametrize("batch_shape",
-                         [(4, 4), (1, 4, 4), (3, 4, 4), ])
-def test_tensor_to_image(batch_shape):
-    tensor = torch.ones(batch_shape)
+@pytest.mark.parametrize("input_shape, expected",
+                         [((4, 4), (4, 4)),
+                          ((1, 4, 4), (4, 4, 1)),
+                          ((3, 4, 4), (4, 4, 3)),
+                          ((2, 3, 4, 4), (2, 4, 4, 3)),
+                          ((1, 3, 4, 4), (1, 4, 4, 3)), ])
+def test_tensor_to_image(input_shape, expected):
+    tensor = torch.ones(input_shape)
     image = kornia.utils.tensor_to_image(tensor)
-    assert image.shape[:2] == batch_shape[-2:]
+    assert image.shape == expected
     assert isinstance(image, np.ndarray)
 
 
-@pytest.mark.parametrize("batch_shape",
-                         [(4, 4), (4, 4, 1), (4, 4, 3), ])
-def test_image_to_tensor(batch_shape):
-    image = np.ones(batch_shape)
+@pytest.mark.parametrize("input_shape, expected",
+                         [((4, 4), (4, 4)),
+                          ((4, 4, 1), (1, 4, 4)),
+                          ((4, 4, 3), (3, 4, 4)),
+                          ((2, 4, 4, 3), (2, 3, 4, 4)),
+                          ((1, 4, 4, 3), (1, 3, 4, 4)), ])
+def test_image_to_tensor(input_shape, expected):
+    image = np.ones(input_shape)
     tensor = kornia.utils.image_to_tensor(image)
-    assert tensor.shape[-2:] == batch_shape[:2]
+    assert tensor.shape == expected
     assert isinstance(tensor, torch.Tensor)


### PR DESCRIPTION
add batch support for image_to_tensor and tensor_to_image functions.
Now support:
`numpy image  <->  torch image` which shape:
`(H, W), (H, W, C), (B, H, W, C) <->  (H, W), (C, H, W,), (B, C, H, W)`

Fix a type checking:
`type(image) == np.ndarray` -> `isinstance(image, np.ndarray)`

Bests