### PR TITLE
Fix rotation_matrix_to_quaternion conversion function

### DIFF
--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -237,6 +237,7 @@ def rotation_matrix_to_quaternion(
         rotation_matrix: torch.Tensor,
         eps: float = 1e-8) -> torch.Tensor:
     r"""Convert 3x3 rotation matrix to 4d quaternion vector.
+    The quaternion vector has components in (x, y, z, w) format.
 
     Args:
         rotation_matrix (torch.Tensor): the rotation matrix to convert.
@@ -250,7 +251,7 @@ def rotation_matrix_to_quaternion(
         - Output: :math:`(*, 4)`
 
     Example:
-        >>> input = torch.rand(4, 3, 4)  # Nx3x4
+        >>> input = torch.rand(4, 3, 3)  # Nx3x3
         >>> output = kornia.rotation_matrix_to_quaternion(input)  # Nx4
     """
     if not isinstance(rotation_matrix, torch.Tensor):
@@ -319,6 +320,7 @@ def rotation_matrix_to_quaternion(
 def normalize_quaternion(quaternion: torch.Tensor,
                          eps: Optional[float] = 1e-12) -> torch.Tensor:
     r"""Normalizes a quaternion.
+    The quaternion should be in (x, y, z, w) format.
 
     Args:
         quaternion (torch.Tensor): a tensor containing a quaternion to be
@@ -351,6 +353,7 @@ def normalize_quaternion(quaternion: torch.Tensor,
 
 def quaternion_to_rotation_matrix(quaternion: torch.Tensor) -> torch.Tensor:
     r"""Converts a quaternion to a rotation matrix.
+    The quaternion should be in (x, y, z, w) format.
 
     Args:
         quaternion (torch.Tensor): a tensor containing a quaternion to be
@@ -408,6 +411,7 @@ def quaternion_to_rotation_matrix(quaternion: torch.Tensor) -> torch.Tensor:
 
 def quaternion_to_angle_axis(quaternion: torch.Tensor) -> torch.Tensor:
     """Convert quaternion vector to angle axis of rotation.
+    The quaternion should be in (x, y, z, w) format.
 
     Adapted from ceres C++ library: ceres-solver/include/ceres/rotation.h
 
@@ -459,6 +463,7 @@ def quaternion_to_angle_axis(quaternion: torch.Tensor) -> torch.Tensor:
 def quaternion_log_to_exp(quaternion: torch.Tensor,
                           eps: float = 1e-8) -> torch.Tensor:
     r"""Applies exponential map to log quaternion.
+    The quaternion should be in (x, y, z, w) format.
 
     Args:
         quaternion (torch.Tensor): a tensor containing a quaternion to be
@@ -497,6 +502,7 @@ def quaternion_log_to_exp(quaternion: torch.Tensor,
 def quaternion_exp_to_log(quaternion: torch.Tensor,
                           eps: float = 1e-8) -> torch.Tensor:
     r"""Applies the log map to a quaternion.
+    The quaternion should be in (x, y, z, w) format.
 
     Args:
         quaternion (torch.Tensor): a tensor containing a quaternion to be
@@ -538,6 +544,7 @@ def quaternion_exp_to_log(quaternion: torch.Tensor,
 
 def angle_axis_to_quaternion(angle_axis: torch.Tensor) -> torch.Tensor:
     r"""Convert an angle axis to a quaternion.
+    The quaternion vector has components in (x, y, z, w) format.
 
     Adapted from ceres C++ library: ceres-solver/include/ceres/rotation.h
 

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -284,32 +284,32 @@ def rotation_matrix_to_quaternion(
         return torch.cat([qx, qy, qz, qw], dim=-1)
 
     def cond_1():
-        sq = torch.sqrt(1.0 + m00 - m11 - m22 + eps) * 2.  # sq = 4 * qw.
+        sq = torch.sqrt(1.0 + m00 - m11 - m22 + eps) * 2.  # sq = 4 * qx.
         qw = safe_zero_division(m21 - m12, sq)
         qx = 0.25 * sq
-        qy = safe_zero_division(m01 - m10, sq)
-        qz = safe_zero_division(m02 - m20, sq)
+        qy = safe_zero_division(m01 + m10, sq)
+        qz = safe_zero_division(m02 + m20, sq)
         return torch.cat([qx, qy, qz, qw], dim=-1)
 
     def cond_2():
-        sq = torch.sqrt(1.0 + m00 - m11 - m22 + eps) * 2.  # sq = 4 * qw.
+        sq = torch.sqrt(1.0 + m11 - m00 - m22 + eps) * 2.  # sq = 4 * qy.
         qw = safe_zero_division(m02 - m20, sq)
-        qx = safe_zero_division(m01 - m10, sq)
+        qx = safe_zero_division(m01 + m10, sq)
         qy = 0.25 * sq
-        qz = safe_zero_division(m12 - m21, sq)
+        qz = safe_zero_division(m12 + m21, sq)
         return torch.cat([qx, qy, qz, qw], dim=-1)
 
     def cond_3():
-        sq = torch.sqrt(1.0 + m00 - m11 - m22 + eps) * 2.  # sq = 4 * qw.
+        sq = torch.sqrt(1.0 + m22 - m00 - m11 + eps) * 2.  # sq = 4 * qz.
         qw = safe_zero_division(m10 - m01, sq)
-        qx = safe_zero_division(m02 - m20, sq)
-        qy = safe_zero_division(m12 - m21, sq)
+        qx = safe_zero_division(m02 + m20, sq)
+        qy = safe_zero_division(m12 + m21, sq)
         qz = 0.25 * sq
         return torch.cat([qx, qy, qz, qw], dim=-1)
 
     where_2 = torch.where(m11 > m22, cond_2(), cond_3())
     where_1 = torch.where(
-        (m00 > m22) & (m00 > m22), cond_1(), where_2)
+        (m00 > m11) & (m00 > m22), cond_1(), where_2)
 
     quaternion: torch.Tensor = torch.where(
         trace > 0., trace_positive_cond(), where_1)

--- a/test/geometry/test_conversions.py
+++ b/test/geometry/test_conversions.py
@@ -100,6 +100,18 @@ class TestRotationMatrixToQuaternion:
         matrix_hat = kornia.quaternion_to_rotation_matrix(quaternion)
         assert_allclose(matrix, matrix_hat)
 
+    def test_corner_case(self):
+        matrix = torch.tensor([
+            [-0.7799533010, -0.5432914495, 0.3106555045],
+            [0.0492402576, -0.5481169224, -0.8349509239],
+            [0.6238971353, -0.6359263659, 0.4542570710]
+        ])
+        quaternion_true = torch.tensor([0.280136495828629, -0.440902262926102,
+                                        0.834015488624573, 0.177614107728004])
+        quaternion = kornia.rotation_matrix_to_quaternion(matrix)
+        torch.set_printoptions(precision=10)
+        assert_allclose(quaternion_true, quaternion)
+
     def test_gradcheck(self):
         matrix = torch.eye(3)
         matrix = tensor_to_gradcheck_var(matrix)


### PR DESCRIPTION
The `rotation_matrix_to_quaternion` function is seemingly incorrect (or the original author did some fancy math which I am not aware of which led to similar answers).

This PR fixes the function to be more like the versions documented in various places such as [here](http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/) and [here](https://github.com/tensorflow/graphics/blob/master/tensorflow_graphics/geometry/transformation/quaternion.py#L259).