### PR TITLE
[ready to review] Normalized version of filters + __repr__

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,0 @@
-[report]
-exclude_lines =
-    pragma: no cover
-    raise

--- a/kornia/filters/blur.py
+++ b/kornia/filters/blur.py
@@ -24,9 +24,10 @@ class BoxBlur(nn.Module):
 
     Args:
         kernel_size (Tuple[int, int]): the blurring kernel size.
-        borde_type (str): the padding mode to be applied before convolving.
+        border_type (str): the padding mode to be applied before convolving.
           The expected modes are: ``'constant'``, ``'reflect'``,
           ``'replicate'`` or ``'circular'``. Default: ``'reflect'``.
+        normalized (bool): if True, L1 norm of the kernel is set to 1.
 
     Returns:
         torch.Tensor: the blurred input tensor.

--- a/kornia/filters/blur.py
+++ b/kornia/filters/blur.py
@@ -5,6 +5,7 @@ import torch.nn as nn
 
 import kornia
 from kornia.filters.kernels import get_box_kernel2d
+from kornia.filters.kernels import normalize_kernel2d
 
 
 class BoxBlur(nn.Module):
@@ -53,9 +54,9 @@ class BoxBlur(nn.Module):
 
     def __repr__(self) -> str:
         return self.__class__.__name__ +\
-               '(kernel_size=' + str(self.kernel_size) + ', '+\
-               'normalized=' + str(self.normalized) + ', ' + \
-               'border_type=' + self.border_type + ')'
+            '(kernel_size=' + str(self.kernel_size) + ', ' +\
+            'normalized=' + str(self.normalized) + ', ' + \
+            'border_type=' + self.border_type + ')'
 
     def forward(self, input: torch.Tensor):  # type: ignore
         return kornia.filter2D(input, self.kernel, self.border_type)

--- a/kornia/filters/blur.py
+++ b/kornia/filters/blur.py
@@ -41,11 +41,21 @@ class BoxBlur(nn.Module):
     """
 
     def __init__(self, kernel_size: Tuple[int, int],
-                 border_type: str = 'reflect') -> None:
+                 border_type: str = 'reflect',
+                 normalized: bool = True) -> None:
         super(BoxBlur, self).__init__()
         self.kernel_size: Tuple[int, int] = kernel_size
         self.border_type: str = border_type
         self.kernel: torch.Tensor = get_box_kernel2d(kernel_size)
+        self.normalized: bool = normalized
+        if self.normalized:
+            self.kernel = normalize_kernel2d(self.kernel)
+
+    def __repr__(self) -> str:
+        return self.__class__.__name__ +\
+               '(kernel_size=' + str(self.kernel_size) + ', '+\
+               'normalized=' + str(self.normalized) + ', ' + \
+               'border_type=' + self.border_type + ')'
 
     def forward(self, input: torch.Tensor):  # type: ignore
         return kornia.filter2D(input, self.kernel, self.border_type)
@@ -56,9 +66,10 @@ class BoxBlur(nn.Module):
 
 def box_blur(input: torch.Tensor,
              kernel_size: Tuple[int, int],
-             border_type: str = 'reflect') -> torch.Tensor:
+             border_type: str = 'reflect',
+             normalized: bool = True) -> torch.Tensor:
     r"""Blurs an image using the box filter.
 
     See :class:`~kornia.filters.BoxBlur` for details.
     """
-    return BoxBlur(kernel_size, border_type)(input)
+    return BoxBlur(kernel_size, border_type, normalized)(input)

--- a/kornia/filters/filter.py
+++ b/kornia/filters/filter.py
@@ -33,7 +33,7 @@ def filter2D(input: torch.Tensor, kernel: torch.Tensor,
         border_type (str): the padding mode to be applied before convolving.
           The expected modes are: ``'constant'``, ``'reflect'``,
           ``'replicate'`` or ``'circular'``. Default: ``'reflect'``.
-        normalized (bool): If True, kernel will be L1 normalized
+        normalized (bool): If True, kernel will be L1 normalized.
 
     Return:
         torch.Tensor: the convolved tensor of same size and numbers of channels

--- a/kornia/filters/filter.py
+++ b/kornia/filters/filter.py
@@ -3,6 +3,7 @@ from typing import Tuple, List
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from kornia.filters.kernels import normalize_kernel2d
 
 
 def compute_padding(kernel_size: Tuple[int, int]) -> List[int]:
@@ -60,7 +61,6 @@ def filter2D(input: torch.Tensor, kernel: torch.Tensor,
 
     borders_list: List[str] = ['constant', 'reflect', 'replicate', 'circular']
     if border_type not in borders_list:
-        raise ValueError("Invalid border_type, we expect the following: {0}."
         raise ValueError("Invalid border_type, we expect the following: {0}."
                          "Got: {1}".format(borders_list, border_type))
 

--- a/kornia/filters/gaussian.py
+++ b/kornia/filters/gaussian.py
@@ -46,6 +46,12 @@ class GaussianBlur2d(nn.Module):
         assert border_type in ["constant", "reflect", "replicate", "circular"]
         self.border_type = border_type
 
+    def __repr__(self) -> str:
+        return self.__class__.__name__ +\
+               '(kernel_size=' + str(self.kernel_size) + ', '+\
+               'sigma=' + str(self.sigma) + ', '+\
+               'border_type=' + self.border_type + ')'
+
     def forward(self, x: torch.Tensor):  # type: ignore
         return kornia.filter2D(x, self.kernel, self.border_type)
 

--- a/kornia/filters/gaussian.py
+++ b/kornia/filters/gaussian.py
@@ -48,9 +48,9 @@ class GaussianBlur2d(nn.Module):
 
     def __repr__(self) -> str:
         return self.__class__.__name__ +\
-               '(kernel_size=' + str(self.kernel_size) + ', '+\
-               'sigma=' + str(self.sigma) + ', '+\
-               'border_type=' + self.border_type + ')'
+            '(kernel_size=' + str(self.kernel_size) + ', ' +\
+            'sigma=' + str(self.sigma) + ', ' +\
+            'border_type=' + self.border_type + ')'
 
     def forward(self, x: torch.Tensor):  # type: ignore
         return kornia.filter2D(x, self.kernel, self.border_type)

--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -7,6 +7,9 @@ import torch.nn as nn
 def normalize_kernel2d(input: torch.Tensor) -> torch.Tensor:
     r"""Normalizes both derivative and smoothing kernel.
     """
+    if len(input.size()) < 2:
+        raise TypeError("input should be at least 2D tensor. Got {}"
+                        .format(input.size()))
     norm: torch.Tensor = input.abs().sum(dim=-1).sum(dim=-1)
     return input / (norm.unsqueeze(-1).unsqueeze(-1))
 

--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -3,6 +3,12 @@ from typing import Tuple, List
 import torch
 import torch.nn as nn
 
+def normalize_kernel2d(input: torch.Tensor) -> torch.Tensor:
+    r"""Normalizes both derivative and smoothing kernel.
+    """
+    norm: torch.Tensor = input.abs().sum(dim=-1).sum(dim=-1)
+    return input / (norm.unsqueeze(-1).unsqueeze(-1))
+
 
 def gaussian(window_size, sigma):
     def gauss_fcn(x):

--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -3,6 +3,7 @@ from typing import Tuple, List
 import torch
 import torch.nn as nn
 
+
 def normalize_kernel2d(input: torch.Tensor) -> torch.Tensor:
     r"""Normalizes both derivative and smoothing kernel.
     """

--- a/kornia/filters/laplacian.py
+++ b/kornia/filters/laplacian.py
@@ -5,7 +5,7 @@ import torch.nn as nn
 
 import kornia
 from kornia.filters.kernels import get_laplacian_kernel2d
-
+from kornia.filters.kernels import normalize_kernel2d
 
 class Laplacian(nn.Module):
     r"""Creates an operator that returns a tensor using a Laplacian filter.
@@ -34,12 +34,22 @@ class Laplacian(nn.Module):
     """
 
     def __init__(self,
-                 kernel_size: int, border_type: str = 'reflect') -> None:
+                 kernel_size: int, border_type: str = 'reflect',
+                 normalized: bool = True) -> None:
         super(Laplacian, self).__init__()
         self.kernel_size: int = kernel_size
         self.border_type: str = border_type
+        self.normalized: bool = normalized
         self.kernel: torch.Tensor = torch.unsqueeze(
             get_laplacian_kernel2d(kernel_size), dim=0)
+        if self.normalized:
+            self.kernel = normalize_kernel2d(self.kernel)
+
+    def __repr__(self) -> str:
+        return self.__class__.__name__ +\
+               '(kernel_size=' + str(self.kernel_size) + ', '+\
+               'normalized=' + str(self.normalized) + ', ' + \
+               'border_type=' + self.border_type + ')'
 
     def forward(self, input: torch.Tensor):  # type: ignore
         return kornia.filter2D(input, self.kernel, self.border_type)
@@ -52,9 +62,11 @@ class Laplacian(nn.Module):
 
 def laplacian(
         input: torch.Tensor,
-        kernel_size: int, border_type: str = 'reflect') -> torch.Tensor:
+        kernel_size: int,
+        border_type: str = 'reflect',
+        normalized: bool = True) -> torch.Tensor:
     r"""Function that returns a tensor using a Laplacian filter.
 
     See :class:`~kornia.filters.Laplacian` for details.
     """
-    return Laplacian(kernel_size, border_type)(input)
+    return Laplacian(kernel_size, border_type, normalized)(input)

--- a/kornia/filters/laplacian.py
+++ b/kornia/filters/laplacian.py
@@ -7,6 +7,7 @@ import kornia
 from kornia.filters.kernels import get_laplacian_kernel2d
 from kornia.filters.kernels import normalize_kernel2d
 
+
 class Laplacian(nn.Module):
     r"""Creates an operator that returns a tensor using a Laplacian filter.
 
@@ -47,9 +48,9 @@ class Laplacian(nn.Module):
 
     def __repr__(self) -> str:
         return self.__class__.__name__ +\
-               '(kernel_size=' + str(self.kernel_size) + ', '+\
-               'normalized=' + str(self.normalized) + ', ' + \
-               'border_type=' + self.border_type + ')'
+            '(kernel_size=' + str(self.kernel_size) + ', ' +\
+            'normalized=' + str(self.normalized) + ', ' + \
+            'border_type=' + self.border_type + ')'
 
     def forward(self, input: torch.Tensor):  # type: ignore
         return kornia.filter2D(input, self.kernel, self.border_type)

--- a/kornia/filters/laplacian.py
+++ b/kornia/filters/laplacian.py
@@ -16,9 +16,10 @@ class Laplacian(nn.Module):
 
     Arguments:
         kernel_size (int): the size of the kernel.
-        borde_type (str): the padding mode to be applied before convolving.
+        border_type (str): the padding mode to be applied before convolving.
           The expected modes are: ``'constant'``, ``'reflect'``,
           ``'replicate'`` or ``'circular'``. Default: ``'reflect'``.
+        normalized (bool): if True, L1 norm of the kernel is set to 1.
 
     Returns:
         Tensor: the tensor.

--- a/kornia/filters/sobel.py
+++ b/kornia/filters/sobel.py
@@ -5,6 +5,7 @@ import torch.nn.functional as F
 from kornia.filters.kernels import get_spatial_gradient_kernel2d
 from kornia.filters.kernels import normalize_kernel2d
 
+
 class SpatialGradient(nn.Module):
     r"""Computes the first order image derivative in both x and y using a Sobel
     operator.
@@ -22,7 +23,7 @@ class SpatialGradient(nn.Module):
     """
 
     def __init__(self,
-                 mode:str = 'sobel',
+                 mode: str = 'sobel',
                  order: int = 1,
                  normalized: bool = True) -> None:
         super(SpatialGradient, self).__init__()
@@ -34,11 +35,11 @@ class SpatialGradient(nn.Module):
             self.kernel = normalize_kernel2d(self.kernel)
         return
 
-    def __repr__(self):
-        return self.__class__.__name__ +\
-               'order=' + str(self.order) + ', ' + \
-               'normalized=' + str(self.normalized) + ', ' + \
-               'mode=' + self.mode + ')'
+    def __repr__(self) -> str:
+        return self.__class__.__name__ + '('\
+            'order=' + str(self.order) + ', ' + \
+            'normalized=' + str(self.normalized) + ', ' + \
+            'mode=' + self.mode + ')'
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:  # type: ignore
         if not torch.is_tensor(input):
@@ -81,8 +82,8 @@ class Sobel(nn.Module):
         self.normalized: bool = normalized
 
     def __repr__(self) -> str:
-        return self.__class__.__name__ +\
-               'normalized=' + str(self.normalized) + ')'
+        return self.__class__.__name__ + '('\
+            'normalized=' + str(self.normalized) + ')'
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:  # type: ignore
         if not torch.is_tensor(input):

--- a/kornia/filters/sobel.py
+++ b/kornia/filters/sobel.py
@@ -67,6 +67,9 @@ class Sobel(nn.Module):
     Return:
         torch.Tensor: the sobel edge gradient maginitudes map.
 
+    Args:
+        normalized (bool): if True, L1 norm of the kernel is set to 1.
+
     Shape:
         - Input: :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
@@ -125,4 +128,4 @@ def sobel(input: torch.Tensor, normalized: bool = True) -> torch.Tensor:
 
     See :class:`~kornia.filters.Sobel` for details.
     """
-    return Sobel(normalized=normalized)(input)
+    return Sobel(normalized)(input)

--- a/kornia/filters/sobel.py
+++ b/kornia/filters/sobel.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from kornia.filters.kernels import get_spatial_gradient_kernel2d
-
+from kornia.filters.kernels import normalize_kernel2d
 
 class SpatialGradient(nn.Module):
     r"""Computes the first order image derivative in both x and y using a Sobel
@@ -21,10 +21,24 @@ class SpatialGradient(nn.Module):
         >>> output = kornia.filters.SpatialGradient()(input)  # 1x3x2x4x4
     """
 
-    def __init__(self, mode: str = 'sobel', order: int = 1) -> None:
+    def __init__(self,
+                 mode:str = 'sobel',
+                 order: int = 1,
+                 normalized: bool = True) -> None:
         super(SpatialGradient, self).__init__()
+        self.normalized: bool = normalized
+        self.order: int = order
+        self.mode: str = mode
         self.kernel = get_spatial_gradient_kernel2d(mode, order)
+        if self.normalized:
+            self.kernel = normalize_kernel2d(self.kernel)
         return
+
+    def __repr__(self):
+        return self.__class__.__name__ +\
+               'order=' + str(self.order) + ', ' + \
+               'normalized=' + str(self.normalized) + ', ' + \
+               'mode=' + self.mode + ')'
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:  # type: ignore
         if not torch.is_tensor(input):
@@ -61,8 +75,14 @@ class Sobel(nn.Module):
         >>> output = kornia.filters.Sobel()(input)  # 1x3x4x4
     """
 
-    def __init__(self) -> None:
+    def __init__(self,
+                 normalized: bool = True) -> None:
         super(Sobel, self).__init__()
+        self.normalized: bool = normalized
+
+    def __repr__(self) -> str:
+        return self.__class__.__name__ +\
+               'normalized=' + str(self.normalized) + ')'
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:  # type: ignore
         if not torch.is_tensor(input):
@@ -72,7 +92,8 @@ class Sobel(nn.Module):
             raise ValueError("Invalid input shape, we expect BxCxHxW. Got: {}"
                              .format(input.shape))
         # comput the x/y gradients
-        edges: torch.Tensor = spatial_gradient(input)
+        edges: torch.Tensor = spatial_gradient(input,
+                                               normalized=self.normalized)
 
         # unpack the edges
         gx: torch.Tensor = edges[:, :, 0]
@@ -88,18 +109,19 @@ class Sobel(nn.Module):
 
 def spatial_gradient(input: torch.Tensor,
                      mode: str = 'sobel',
-                     order: int = 1) -> torch.Tensor:
+                     order: int = 1,
+                     normalized: bool = True) -> torch.Tensor:
     r"""Computes the first order image derivative in both x and y using a Sobel
     operator.
 
     See :class:`~kornia.filters.SpatialGradient` for details.
     """
-    return SpatialGradient(mode, order)(input)
+    return SpatialGradient(mode, order, normalized)(input)
 
 
-def sobel(input: torch.Tensor) -> torch.Tensor:
+def sobel(input: torch.Tensor, normalized: bool = True) -> torch.Tensor:
     r"""Computes the Sobel operator and returns the magnitude per channel.
 
     See :class:`~kornia.filters.Sobel` for details.
     """
-    return Sobel()(input)
+    return Sobel(normalized=normalized)(input)

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,13 @@ max-line-length = 80
 max-line-length = 80
 ignore = F401,E402,F403,F811
 exclude = venv
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if self.debug:
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,12 +15,11 @@ max-line-length = 80
 ignore = F401,E402,F403,F811
 exclude = venv
 
-[report]
+[coverage:report]
 exclude_lines =
     pragma: no cover
     def __repr__
     if self.debug:
-    raise AssertionError
-    raise NotImplementedError
+    raise
     if 0:
     if __name__ == .__main__.:

--- a/test/filters/test_filters.py
+++ b/test/filters/test_filters.py
@@ -67,14 +67,13 @@ class TestFilter2D:
         ]]]).expand(2, 2, -1, -1)
         expected = torch.tensor([[[
             [0., 0., 0., 0., 0.],
-            [0., 5./9., 5./9., 5./9., 0.],
-            [0., 5./9., 5./9., 5./9., 0.],
-            [0., 5./9., 5./9., 5./9., 0.],
+            [0., 5. / 9., 5. / 9., 5. / 9., 0.],
+            [0., 5. / 9., 5. / 9., 5. / 9., 0.],
+            [0., 5. / 9., 5. / 9., 5. / 9., 0.],
             [0., 0., 0., 0., 0.],
         ]]])
         actual = kornia.filter2D(input, kernel, normalized=True)
         assert_allclose(actual, expected)
-
 
     def test_gradcheck(self):
         kernel = torch.rand(1, 3, 3)

--- a/test/filters/test_filters.py
+++ b/test/filters/test_filters.py
@@ -56,6 +56,26 @@ class TestFilter2D:
         actual = kornia.filter2D(input, kernel)
         assert_allclose(actual, expected)
 
+    def test_normalized_mean_filter(self):
+        kernel = torch.ones(1, 3, 3)
+        input = torch.tensor([[[
+            [0., 0., 0., 0., 0.],
+            [0., 0., 0., 0., 0.],
+            [0., 0., 5., 0., 0.],
+            [0., 0., 0., 0., 0.],
+            [0., 0., 0., 0., 0.],
+        ]]]).expand(2, 2, -1, -1)
+        expected = torch.tensor([[[
+            [0., 0., 0., 0., 0.],
+            [0., 5./9., 5./9., 5./9., 0.],
+            [0., 5./9., 5./9., 5./9., 0.],
+            [0., 5./9., 5./9., 5./9., 0.],
+            [0., 0., 0., 0., 0.],
+        ]]])
+        actual = kornia.filter2D(input, kernel, normalized=True)
+        assert_allclose(actual, expected)
+
+
     def test_gradcheck(self):
         kernel = torch.rand(1, 3, 3)
         input = torch.ones(1, 1, 7, 8)

--- a/test/filters/test_sobel.py
+++ b/test/filters/test_sobel.py
@@ -71,7 +71,6 @@ class TestSpatialGradient:
         edges = kornia.filters.spatial_gradient(inp, normalized=True)
         assert_allclose(edges, expected)
 
-
     def test_edges_sep(self):
         inp = torch.tensor([[[
             [0., 0., 0., 0., 0.],
@@ -94,7 +93,8 @@ class TestSpatialGradient:
             [0., -1., -1., -1., 0.],
             [0., 0., -1., 0., 0.]
         ]]]])
-        edges = kornia.filters.spatial_gradient(inp, 'diff', False)
+        edges = kornia.filters.spatial_gradient(inp, 'diff',
+                                                normalized=False)
         assert_allclose(edges, expected)
 
     def test_edges_sep_norm(self):
@@ -119,7 +119,8 @@ class TestSpatialGradient:
             [0., -1., -1., -1., 0.],
             [0., 0., -1., 0., 0.]
         ]]]]) / 2.0
-        edges = kornia.filters.spatial_gradient(inp, 'diff')
+        edges = kornia.filters.spatial_gradient(inp, 'diff',
+                                                normalized=True)
         assert_allclose(edges, expected)
 
     def test_gradcheck(self):
@@ -171,18 +172,19 @@ class TestSobel:
         edges = kornia.filters.sobel(inp, normalized=False)
         assert_allclose(edges, expected)
 
-
     def test_gradcheck_unnorm(self):
         batch_size, channels, height, width = 1, 2, 5, 4
         img = torch.rand(batch_size, channels, height, width)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.filters.sobel, (img, False), raise_exception=True)
+        assert gradcheck(kornia.filters.sobel, (img, False),
+                         raise_exception=True)
 
     def test_gradcheck(self):
         batch_size, channels, height, width = 1, 2, 5, 4
         img = torch.rand(batch_size, channels, height, width)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.filters.sobel, (img, True), raise_exception=True)
+        assert gradcheck(kornia.filters.sobel, (img, True),
+                         raise_exception=True)
 
     @pytest.mark.skip(reason="turn off all jit for a while")
     def test_jit(self):

--- a/test/filters/test_sobel.py
+++ b/test/filters/test_sobel.py
@@ -42,7 +42,7 @@ class TestSpatialGradient:
             [0., -1., -2., -1., 0.],
         ]]]])
 
-        edges = kornia.filters.spatial_gradient(inp)
+        edges = kornia.filters.spatial_gradient(inp, normalized=False)
         assert_allclose(edges, expected)
 
     def test_edges_sep(self):
@@ -116,7 +116,7 @@ class TestSobel:
             [0., 1.4142, 2.0, 1.4142, 0.],
         ]]])
 
-        edges = kornia.filters.sobel(inp)
+        edges = kornia.filters.sobel(inp, normalized=False)
         assert_allclose(edges, expected)
 
     def test_gradcheck(self):


### PR DESCRIPTION
For better propagation it is beneficil to bound the output. Now, if one applies different filters in chain, the norm of the feature map grows very fast.
With L1 normalization of the kernel is not a such problem.
It will also simplifies things for Harris and Hessian implementation