### PR TITLE
Fix typo in color files

### DIFF
--- a/kornia/color/gray.py
+++ b/kornia/color/gray.py
@@ -20,7 +20,7 @@ class RgbToGrayscale(nn.Module):
     Examples::
 
         >>> input = torch.rand(2, 3, 4, 5)
-        >>> gray = kornia.image.RgbToGrayscale()
+        >>> gray = kornia.color.RgbToGrayscale()
         >>> output = gray(input)  # 2x1x4x5
     """
 

--- a/kornia/color/gray.py
+++ b/kornia/color/gray.py
@@ -50,7 +50,6 @@ def rgb_to_grayscale(input: torch.Tensor) -> torch.Tensor:
         raise ValueError("Input size must have a shape of (*, 3, H, W). Got {}"
                          .format(input.shape))
 
-
     # https://docs.opencv.org/4.0.1/de/d25/imgproc_color_conversions.html
     r, g, b = torch.chunk(input, chunks=3, dim=-3)
     gray: torch.Tensor = 0.299 * r + 0.587 * g + 0.110 * b

--- a/kornia/color/gray.py
+++ b/kornia/color/gray.py
@@ -8,7 +8,7 @@ class RgbToGrayscale(nn.Module):
     the image data is assumed to be in the range of (0, 1).
 
     args:
-        input (torch.Tensor): image to be converted to grayscale.
+        input (torch.Tensor): RGB image to be converted to grayscale.
 
     returns:
         torch.Tensor: grayscale version of the image.
@@ -37,7 +37,7 @@ def rgb_to_grayscale(input: torch.Tensor) -> torch.Tensor:
     See :class:`~kornia.color.RgbToGrayscale` for details.
 
     Args:
-        input (torch.Tensor): Image to be converted to grayscale.
+        input (torch.Tensor): RGB image to be converted to grayscale.
 
     Returns:
         torch.Tensor: Grayscale version of the image.

--- a/kornia/color/hsv.py
+++ b/kornia/color/hsv.py
@@ -19,7 +19,7 @@ class HsvToRgb(nn.Module):
     Examples::
 
         >>> input = torch.rand(2, 3, 4, 5)
-        >>> rgb = kornia.image.HsvToRgb()
+        >>> rgb = kornia.color.HsvToRgb()
         >>> output = rgb(input)  # 2x3x4x5
 
     """
@@ -91,7 +91,7 @@ class RgbToHsv(nn.Module):
     Examples::
 
         >>> input = torch.rand(2, 3, 4, 5)
-        >>> hsv = kornia.image.RgbToHsv()
+        >>> hsv = kornia.color.RgbToHsv()
         >>> output = hsv(input)  # 2x3x4x5
 
     """

--- a/kornia/color/hsv.py
+++ b/kornia/color/hsv.py
@@ -7,14 +7,20 @@ class HsvToRgb(nn.Module):
     The image data is assumed to be in the range of (0, 1).
 
     args:
-        image (torch.Tensor): RGB image to be converted to HSV.
+        image (torch.Tensor): HSV image to be converted to RGB.
 
     returns:
-        torch.tensor: HSV version of the image.
+        torch.tensor: RGB version of the image.
 
     shape:
         - image: :math:`(*, 3, H, W)`
         - output: :math:`(*, 3, H, W)`
+
+    Examples::
+
+        >>> input = torch.rand(2, 3, 4, 5)
+        >>> rgb = kornia.image.HsvToRgb()
+        >>> output = rgb(input)  # 2x3x4x5
 
     """
 
@@ -30,11 +36,11 @@ def hsv_to_rgb(image):
     The image data is assumed to be in the range of (0, 1).
 
     Args:
-        input (torch.Tensor): RGB Image to be converted to HSV.
+        input (torch.Tensor): HSV Image to be converted to RGB.
 
 
     Returns:
-        torch.Tensor: HSV version of the image.
+        torch.Tensor: RGB version of the image.
     """
 
     if not torch.is_tensor(image):
@@ -81,6 +87,12 @@ class RgbToHsv(nn.Module):
     shape:
         - image: :math:`(*, 3, H, W)`
         - output: :math:`(*, 3, H, W)`
+
+    Examples::
+
+        >>> input = torch.rand(2, 3, 4, 5)
+        >>> hsv = kornia.image.RgbToHsv()
+        >>> output = hsv(input)  # 2x3x4x5
 
     """
 

--- a/kornia/color/rgb.py
+++ b/kornia/color/rgb.py
@@ -17,6 +17,12 @@ class RgbToBgr(nn.Module):
         - image: :math:`(*, 3, H, W)`
         - output: :math:`(*, 3, H, W)`
 
+    Examples::
+
+        >>> input = torch.rand(2, 3, 4, 5)
+        >>> bgr = kornia.image.RgbToBgr()
+        >>> output = bgr(input)  # 2x3x4x5
+
     """
 
     def __init__(self) -> None:
@@ -55,6 +61,12 @@ class BgrToRgb(nn.Module):
     shape:
         - image: :math:`(*, 3, H, W)`
         - output: :math:`(*, 3, H, W)`
+
+    Examples::
+
+        >>> input = torch.rand(2, 3, 4, 5)
+        >>> rgb = kornia.image.BgrToRgb()
+        >>> output = rgb(input)  # 2x3x4x5
 
     """
 

--- a/kornia/color/rgb.py
+++ b/kornia/color/rgb.py
@@ -20,7 +20,7 @@ class RgbToBgr(nn.Module):
     Examples::
 
         >>> input = torch.rand(2, 3, 4, 5)
-        >>> bgr = kornia.image.RgbToBgr()
+        >>> bgr = kornia.color.RgbToBgr()
         >>> output = bgr(input)  # 2x3x4x5
 
     """
@@ -65,7 +65,7 @@ class BgrToRgb(nn.Module):
     Examples::
 
         >>> input = torch.rand(2, 3, 4, 5)
-        >>> rgb = kornia.image.BgrToRgb()
+        >>> rgb = kornia.color.BgrToRgb()
         >>> output = rgb(input)  # 2x3x4x5
 
     """


### PR DESCRIPTION
I've found some typos in hsv.py, in the commented summary section, so I fixed them, and added class example in the rest of color conversions files.